### PR TITLE
ft: #5 forward data from client to server through tunnel

### DIFF
--- a/packages/tunlrs-core/src/tunnel/tunnelmanager.rs
+++ b/packages/tunlrs-core/src/tunnel/tunnelmanager.rs
@@ -1,0 +1,5 @@
+pub struct TunnelManager {
+    exposed_port: u16,
+    redirect_port: u16
+}
+


### PR DESCRIPTION
Add in simple functionality that allows client data in the TCP packet to be forwarded to the server through the tunnel service.