### PR TITLE
Async tcp object spawn

### DIFF
--- a/packages/tunlrs-core/src/tunnel/tunnel.rs
+++ b/packages/tunlrs-core/src/tunnel/tunnel.rs
@@ -2,6 +2,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::net::TcpStream;
 
+use crate::tunnel::tunnelconnection::TunnelConnection;
+
 const LISTEN_PORT: u16 = 5000;
 const REPLY_PORT: u16 = 6000;
 
@@ -19,31 +21,37 @@ async fn tunnel_loop() -> Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind("127.0.0.1:5000").await?;
     loop {
         let (mut stream, socket) = listener.accept().await?;
+        let mut tunnel_connection_object = TunnelConnection::new(stream, socket, "127.0.0.1".to_string(), 5050);
         tokio::spawn(async move {
-            let mut buf = [0; 4096];
-
-            loop {
-                let n = stream
-                    .read(&mut buf)
-                    .await
-                    .expect("Had an error in reading!");
-
-                if n == 0 {
-                    return;
-                }
-                /* open a stream here and wait until we get a reply from machine */
-                println!("Got message: {:?} @ {:?}", &buf[0..n], socket);
-                tunnel_to_machine(&buf[0..n]).await.expect("");
-
-                stream
-                    .write_all(&buf[0..n])
-                    .await
-                    .expect("Error writing to client!");
-                println!("Wrote to client!");
-
-                stream.shutdown().await.expect("Shutdown failed!");
-            }
+            tunnel_connection_object.connect().await;
+            tunnel_connection_object.relay_to_server().await;
         });
+
+        // tokio::spawn(async move {
+        //     let mut buf = [0; 4096];
+
+        //     loop {
+        //         let n = stream
+        //             .read(&mut buf)
+        //             .await
+        //             .expect("Had an error in reading!");
+
+        //         if n == 0 {
+        //             return;
+        //         }
+        //         /* open a stream here and wait until we get a reply from machine */
+        //         println!("Got message: {:?} @ {:?}", &buf[0..n], socket);
+        //         tunnel_to_machine(&buf[0..n]).await.expect("");
+
+        //         stream
+        //             .write_all(&buf[0..n])
+        //             .await
+        //             .expect("Error writing to client!");
+        //         println!("Wrote to client!");
+
+        //         stream.shutdown().await.expect("Shutdown failed!");
+        //     }
+        // });
     }
 }
 

--- a/packages/tunlrs-core/src/tunnel/tunnel.rs
+++ b/packages/tunlrs-core/src/tunnel/tunnel.rs
@@ -21,7 +21,8 @@ async fn tunnel_loop() -> Result<(), Box<dyn std::error::Error>> {
     let listener = TcpListener::bind("127.0.0.1:5000").await?;
     loop {
         let (mut stream, socket) = listener.accept().await?;
-        let mut tunnel_connection_object = TunnelConnection::new(stream, socket, "127.0.0.1".to_string(), 5050);
+        let mut tunnel_connection_object =
+            TunnelConnection::new(stream, socket, "127.0.0.1".to_string(), 5050);
         tokio::spawn(async move {
             tunnel_connection_object.connect().await;
             tunnel_connection_object.relay_to_server().await;

--- a/packages/tunlrs-core/src/tunnel/tunnelconnection.rs
+++ b/packages/tunlrs-core/src/tunnel/tunnelconnection.rs
@@ -68,15 +68,15 @@ impl TunnelConnection {
         /* do other connect stuff */
     }
     pub fn relay_to_server(&mut self) {
-        let mut callback = self.on_client_read.take();
-        self.consume_callback_function(callback);
+        let client_read_callback = self.on_client_read.take();
+        self.consume_callback_function(client_read_callback);
         /* do other relay_to_server stuff */
 
-        callback = self.on_server_request.take();
-        self.consume_callback_function(callback);
+        let server_req_callback = self.on_server_request.take();
+        self.consume_callback_function(server_req_callback);
         /* do stuff in between request and response */
-        callback = self.on_server_response.take();
-        self.consume_callback_function(callback);
+        let server_res_callback = self.on_server_response.take();
+        self.consume_callback_function(server_res_callback);
         /* do stuff after getting client request */
     }
     pub fn reply_to_client(&mut self) {

--- a/packages/tunlrs-core/src/tunnel/tunnelconnection.rs
+++ b/packages/tunlrs-core/src/tunnel/tunnelconnection.rs
@@ -2,7 +2,7 @@ use ::core::net::SocketAddr;
 use ::tokio::net::{TcpSocket, TcpStream};
 
 /* verify procedure for writing for server machine. */
-type function_callback = Box<dyn Fn() + Send + Sync>;
+type function_callback = Box<dyn Fn(&TunnelConnection) + Send + Sync>;
 
 pub struct TunnelConnection {
     client_stream: TcpStream,

--- a/packages/tunlrs-core/src/tunnel/tunnelconnection.rs
+++ b/packages/tunlrs-core/src/tunnel/tunnelconnection.rs
@@ -50,7 +50,7 @@ impl TunnelConnection {
 
     fn consume_callback_function(&mut self, func: Option<function_callback>) -> () {
         match func {
-            Some(x) => x(),
+            Some(x) => x(&self),
             None => (),
         }
     }


### PR DESCRIPTION
PS: still need to fix the read server response functionality - currently after forwarding from client to server, the function blocks until the client connection is de-established(i.e, Ctrl+C on the client netcat window..) - this will have to be fixed. Perhaps something like an `async move ()` can work here?